### PR TITLE
Add printing of gradients, no file out, simplify stepped gradients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
-*.notes
-*.DS_Store
+**/*.notes
+**/.DS_Store
 img
 res
+/*.jpg
+/*.png

--- a/src/lib/linear.rs
+++ b/src/lib/linear.rs
@@ -1,6 +1,6 @@
 use palette::{Gradient, LinSrgb, Pixel, Srgb};
 
-use crate::{generate_filename, Config};
+use crate::{generate_filename, Config, print_colors};
 
 pub fn linear_gradient_continuous(config: Config) -> std::io::Result<()> {
     let grad = Gradient::new(config.grad_vec);
@@ -20,44 +20,35 @@ pub fn linear_gradient_continuous(config: Config) -> std::io::Result<()> {
     }
 
     let title = generate_filename();
-    imgbuf.save(title).expect("Could not save file");
+    imgbuf.save(title.unwrap()).expect("Could not save file");
 
     Ok(())
 }
 
 pub fn linear_gradient_stepped(config: Config) -> std::io::Result<()> {
-    let num_steps;
-    let vec_len = config.grad_vec.len();
-    if vec_len == 2 {
-        if config.steps > 1 {
-            num_steps = vec_len + config.steps as usize;
-        } else if config.steps == 1 {
-            num_steps = (vec_len * config.steps as usize) + 1;
-        } else {
-            num_steps = vec_len;
-        }
-    } else {
-        num_steps = (vec_len - 1) * (config.steps as usize) + 1;
+    let grad1 = Gradient::new(config.grad_vec);
+    let grad2 = grad1.take(config.steps);
+
+    let mut grad_vec = Vec::with_capacity(config.steps);
+    for color in grad2 {
+        let pix = Srgb::from_linear(LinSrgb::from(color));
+        grad_vec.push(pix);
     }
 
-    let grad1 = Gradient::new(config.grad_vec);
-    let grad2 = grad1.take(num_steps);
-
-    let mut grad_vec = Vec::with_capacity(num_steps);
-    for color in grad2 {
-        let pix: [u8; 3] = Srgb::from_linear(LinSrgb::from(color))
-            .into_format()
-            .into_raw();
-        grad_vec.push(pix);
+    if config.print_grad {
+        print_colors(&grad_vec)?;
+    }
+    if config.no_file {
+        return Ok(());
     }
 
     let img_x = config.swatch_size.0;
     let img_y = config.swatch_size.1;
     let mut imgbuf: image::RgbImage =
-        image::ImageBuffer::new(img_x * num_steps as u32, img_y as u32);
+        image::ImageBuffer::new(img_x * config.steps as u32, img_y as u32);
 
-    for s in 0..num_steps {
-        let pix: [u8; 3] = grad_vec[s];
+    for s in 0..config.steps {
+        let pix: [u8; 3] = grad_vec[s].into_format().into_raw();
         for y in 0..img_y {
             for x in (s as u32 * img_x)..((s as u32 + 1) * img_x) {
                 let pixel = imgbuf.get_pixel_mut(x, y);
@@ -67,7 +58,7 @@ pub fn linear_gradient_stepped(config: Config) -> std::io::Result<()> {
     }
 
     let title = generate_filename();
-    imgbuf.save(title).expect("Could not save file");
+    imgbuf.save(title.unwrap()).expect("Could not save file");
 
     Ok(())
 }

--- a/src/lib/radial.rs
+++ b/src/lib/radial.rs
@@ -1,6 +1,6 @@
 use palette::{Blend, Gradient, LinSrgb, LinSrgba, Pixel, Srgb, Srgba};
 
-use crate::{generate_filename, Config};
+use crate::{generate_filename, print_colors, Config};
 
 fn midpoint_xy_dist(size_x: u32, size_y: u32, x2: u32, y2: u32) -> [f32; 2] {
     let mut result: [f32; 2] = [0.0, 0.0];
@@ -45,33 +45,26 @@ pub fn radial_gradient_continuous(config: Config) -> std::io::Result<()> {
         *pixel = image::Rgba(pix);
     }
     let title = generate_filename();
-    imgbuf.save(title).expect("Could not save file");
+    imgbuf.save(title.unwrap()).expect("Could not save file");
 
     Ok(())
 }
 
 pub fn radial_gradient_stepped(config: Config) -> std::io::Result<()> {
-    let num_steps;
-    let vec_len = config.grad_vec.len();
-    if vec_len == 2 {
-        if config.steps > 1 {
-            num_steps = vec_len + config.steps as usize;
-        } else if config.steps == 1 {
-            num_steps = (vec_len * config.steps as usize) + 1;
-        } else {
-            num_steps = vec_len;
-        }
-    } else {
-        num_steps = (vec_len - 1) * (config.steps as usize) + 1;
-    }
-
     let grad1 = Gradient::new(config.grad_vec);
-    let grad2 = grad1.take(num_steps);
+    let grad2 = grad1.take(config.steps);
 
-    let mut grad_vec = Vec::with_capacity(num_steps);
+    let mut grad_vec = Vec::with_capacity(config.steps);
     for color in grad2 {
         let pix = Srgb::from_linear(LinSrgb::from(color));
         grad_vec.push(pix);
+    }
+
+    if config.print_grad {
+        print_colors(&grad_vec)?;
+    }
+    if config.no_file {
+        return Ok(());
     }
 
     let img_x = config.size;
@@ -109,7 +102,7 @@ pub fn radial_gradient_stepped(config: Config) -> std::io::Result<()> {
         *pixel = image::Rgba(pix);
     }
     let title = generate_filename();
-    imgbuf.save(title).expect("Could not save file");
+    imgbuf.save(title.unwrap()).expect("Could not save file");
 
     Ok(())
 }
@@ -153,7 +146,7 @@ pub fn radial_gradient_with_overlay(config: Config) -> std::io::Result<()> {
     }
 
     let title = generate_filename();
-    imgbuf.save(title).expect("Could not save file");
+    imgbuf.save(title.unwrap()).expect("Could not save file");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn try_main() -> Result<(), Box<dyn Error>> {
                 .short("n")
                 .long("steps")
                 .alias("st")
-                .help("Number of color steps between each color")
+                .help("Number of color steps in the gradient")
                 .takes_value(true)
                 .required(false)
                 .default_value("11"),
@@ -150,6 +150,17 @@ fn try_main() -> Result<(), Box<dyn Error>> {
                 .takes_value(true)
                 .default_value("40x40")
                 .value_delimiter("x"),
+        )
+        .arg(
+            Arg::with_name("print")
+            .short("p")
+            .long("print")
+            .help("Print colors produced by stepped gradients")
+        )
+        .arg(
+            Arg::with_name("no file")
+            .long("no-file")
+            .help("Don't output file, for use with printing stepped gradient colors")
         )
         .get_matches();
 
@@ -320,7 +331,20 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let angle_offset = core::f32::consts::FRAC_PI_2;
     let overlay_factor = 0.9;
     let size = m.value_of("size").unwrap().parse::<u32>()?;
-    let steps = m.value_of("steps").unwrap().parse::<u32>()?;
+    let steps = m.value_of("steps").unwrap().parse::<usize>()?;
+
+    let print_grad;
+    if m.is_present("print") {
+        print_grad = true;
+    } else {
+        print_grad = false;
+    }
+    let no_file;
+    if m.is_present("no file") {
+        no_file = true;
+    } else {
+        no_file = false;
+    }
 
     let config = Config {
         angle_offset,
@@ -330,6 +354,8 @@ fn try_main() -> Result<(), Box<dyn Error>> {
         output_file,
         overlay,
         overlay_factor,
+        no_file,
+        print_grad,
         size,
         steps,
         swatch_size,


### PR DESCRIPTION
Add flag to print colors produced by stepped gradients
Add no output flag to not write file
Simplify stepped gradients to take `-n` steps instead of trying to do math

Closes #4 